### PR TITLE
feat: enhance API documentation for user profile endpoints

### DIFF
--- a/apps/core/schema.py
+++ b/apps/core/schema.py
@@ -20,4 +20,9 @@ UNAUTHORIZED_EXAMPLES = [
         value={"detail": "Invalid token."},
         status_codes=["401"],
     ),
+    OpenApiExample(
+        "Invalid token header",
+        value={"detail": "Invalid token header. No credentials provided."},
+        status_codes=["401"],
+    ),
 ]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib.auth import login
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from knox.views import LoginView as KnoxLoginView
 from rest_framework import generics, permissions, throttling
 from rest_framework.response import Response
@@ -45,6 +45,11 @@ class LoginView(KnoxLoginView):
         return context
 
 
+@extend_schema_view(
+    get=extend_schema(responses=PROFILE_DETAIL_SCHEMA),
+    patch=extend_schema(responses=PROFILE_PATCH_SCHEMA),
+    put=extend_schema(responses=PROFILE_PUT_SCHEMA),
+)
 class UserProfileView(generics.RetrieveUpdateAPIView):
     serializer_class = UserProfileSerializer
     permission_classes = (permissions.IsAuthenticated,)
@@ -52,18 +57,6 @@ class UserProfileView(generics.RetrieveUpdateAPIView):
 
     def get_object(self):
         return self.request.user
-
-    @extend_schema(responses=PROFILE_DETAIL_SCHEMA)
-    def get(self, request, *args, **kwargs):
-        return super().get(request, *args, **kwargs)
-
-    @extend_schema(responses=PROFILE_PATCH_SCHEMA)
-    def patch(self, request, *args, **kwargs):
-        return super().patch(request, *args, **kwargs)
-
-    @extend_schema(responses=PROFILE_PUT_SCHEMA)
-    def put(self, request, *args, **kwargs):
-        return super().put(request, *args, **kwargs)
 
 
 @extend_schema(responses=USER_CREATE_RESPONSE_SCHEMA)


### PR DESCRIPTION
This pull request includes changes to improve the OpenAPI documentation and simplify the codebase in the `apps/users/views.py` file. The most important changes include adding a new OpenAPI example for invalid token headers and refactoring the `UserProfileView` class to use `extend_schema_view`.

Improvements to OpenAPI documentation:

* [`apps/core/schema.py`](diffhunk://#diff-3e43cca0123f1f8e7b657d1649d13336c51ddde689f0746fb47661699262af7aR23-R27): Added a new `OpenApiExample` for "Invalid token header" to provide a more detailed error message when no credentials are provided.

Codebase simplification:

* [`apps/users/views.py`](diffhunk://#diff-590854d95befb63c4999dd49b45e7ff74ae91a7f256377ad1124ee1d2530cc15L4-R4): Imported `extend_schema_view` from `drf_spectacular.utils` to enable schema extension for class-based views.
* [`apps/users/views.py`](diffhunk://#diff-590854d95befb63c4999dd49b45e7ff74ae91a7f256377ad1124ee1d2530cc15R48-R52): Applied `@extend_schema_view` decorator to the `UserProfileView` class to consolidate the schema extension for `get`, `patch`, and `put` methods, removing individual method decorators. [[1]](diffhunk://#diff-590854d95befb63c4999dd49b45e7ff74ae91a7f256377ad1124ee1d2530cc15R48-R52) [[2]](diffhunk://#diff-590854d95befb63c4999dd49b45e7ff74ae91a7f256377ad1124ee1d2530cc15L56-L67)