### PR TITLE
Bug fixes

### DIFF
--- a/apps/core/management/commands/seed.py
+++ b/apps/core/management/commands/seed.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from django.db import transaction
+from django.db import IntegrityError, transaction
 
 from apps.users.models import CustomUser
 
@@ -20,7 +20,6 @@ class Command(BaseCommand):
             "--clean", action="store_true", help="Delete all data before seeding"
         )
 
-    @transaction.atomic
     def handle(self, *args, **options):
         if options["clean"]:
             self.stdout.write("Deleting old data...")
@@ -39,9 +38,10 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.SUCCESS(f"Superuser created - {superuser.email}")
             )
-        except Exception as e:
+        except IntegrityError as e:
             self.stdout.write(self.style.WARNING(f"Superuser already exists - {e}"))
 
+    @transaction.atomic
     def create_users(self, count):
         try:
             from faker import Faker
@@ -57,6 +57,7 @@ class Command(BaseCommand):
         self.stdout.write(f"Creating {count} users...")
 
         for _ in range(count):
+            sid = transaction.savepoint()
             try:
                 user = CustomUser.objects.create_user(
                     email=fake.email(),
@@ -64,6 +65,8 @@ class Command(BaseCommand):
                     first_name=fake.first_name(),
                     last_name=fake.last_name(),
                 )
+                transaction.savepoint_commit(sid)
                 self.stdout.write(f"Created user - {user.email}")
-            except Exception as e:
+            except IntegrityError as e:
+                transaction.savepoint_rollback(sid)
                 self.stdout.write(self.style.WARNING(f"Error creating user - {e}"))

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -35,7 +35,7 @@ class RequestIDMiddleware:
         path_var.set(request.path)
 
         if hasattr(request, "user") and request.user.is_authenticated:
-            user_id_var.set(str(getattr(request.user, "id", "anonymous")))
+            user_id_var.set(str(getattr(request.user, "pk", "anonymous")))
         else:
             user_id_var.set("anonymous")
 

--- a/apps/core/tasks.py
+++ b/apps/core/tasks.py
@@ -21,7 +21,7 @@ class BaseTaskWithRetry(celery.Task):
     """
 
     # The list of exceptions that should be caught and retried
-    autoretry_for = (Exception, KeyError)
+    autoretry_for = (Exception,)
 
     # The maximum number of retries this task can have
     retry_kwargs = {"max_retries": 3}

--- a/apps/core/tests/test_core_views.py
+++ b/apps/core/tests/test_core_views.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+
 from apps.core.views import PingRateThrottle
 
 
@@ -28,6 +29,4 @@ class CoreViewsTests(APITestCase):
         for method in methods:
             with self.subTest(method=method):
                 response = getattr(self.client, method)(self.ping_url)
-                self.assertEqual(
-                    response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
-                )
+                self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/apps/users/managers.py
+++ b/apps/users/managers.py
@@ -26,7 +26,7 @@ class CustomUserManager(BaseUserManager):
         email = self.normalize_email(email)
         user = self.model(email=email, **extra_fields)
         user.set_password(password)
-        user.save()
+        user.save(using=self._db)
         return user
 
     def create_superuser(

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -84,13 +84,15 @@ class UserProfileSerializer(serializers.ModelSerializer):
         model = CustomUser
         fields = ("email", "password", "first_name", "last_name")
         extra_kwargs = {
-            "password": {"write_only": True, "min_length": MIN_PASSWORD_LENGTH}
+            "email": {"read_only": True},
+            "password": {"write_only": True, "min_length": MIN_PASSWORD_LENGTH},
         }
 
     def validate(self, data: dict) -> dict:
         if "password" in data:
             try:
-                validate_password(data["password"], self.Meta.model(**data))
+                user = self.instance if self.instance else self.Meta.model(**data)
+                validate_password(data["password"], user=user)
             except Exception as e:
                 if hasattr(e, "error_list"):
                     errors = get_errors(e)

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 from django.conf import settings
 from django.contrib.auth import authenticate
@@ -29,8 +30,11 @@ class AuthTokenSerializer(serializers.Serializer):
 
         # The authenticate call simply returns None for is_active=False users
         if email and password:
-            user: CustomUser = authenticate(
-                request=self.context.get("request"), email=email, password=password
+            user = cast(
+                CustomUser | None,
+                authenticate(
+                    request=self.context.get("request"), email=email, password=password
+                ),
             )
 
             if not user:

--- a/apps/users/tests/test_create_user_view.py
+++ b/apps/users/tests/test_create_user_view.py
@@ -1,9 +1,10 @@
+import logging
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from django.contrib.auth import get_user_model
-from unittest.mock import patch
-import logging
 
 
 class CreateUserViewTests(APITestCase):
@@ -40,9 +41,7 @@ class CreateUserViewTests(APITestCase):
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("non_field_errors", response.data)
-        self.assertEqual(
-            response.data["non_field_errors"][0], "Passwords do not match."
-        )
+        self.assertEqual(response.data["non_field_errors"][0], "Passwords do not match.")
 
     def test_create_user_weak_password(self):
         """Test creating user with weak password"""
@@ -107,6 +106,4 @@ class CreateUserViewTests(APITestCase):
         for method in methods:
             with self.subTest(method=method):
                 response = getattr(self.client, method)(self.url)
-                self.assertEqual(
-                    response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
-                )
+                self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/apps/users/tests/test_login_view.py
+++ b/apps/users/tests/test_login_view.py
@@ -1,10 +1,12 @@
+import logging
+from unittest.mock import ANY, patch
+
+from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+
 from apps.users.models import CustomUser as User
-from unittest.mock import patch, ANY
-import logging
-from django.core.cache import cache
 
 
 class LoginViewTests(APITestCase):
@@ -142,9 +144,7 @@ class LoginViewTests(APITestCase):
         for method in methods:
             with self.subTest(method=method):
                 response = getattr(self.client, method)(self.url)
-                self.assertEqual(
-                    response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
-                )
+                self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
                 self.assertIn("POST", response["Allow"])
 
     def test_login_throttling(self):
@@ -191,7 +191,7 @@ class LoginViewTests(APITestCase):
 
         # All tokens should be valid
         for token in tokens:
-            self.client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+            self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
             profile_url = reverse("v1:users:profile")
             response = self.client.get(profile_url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/users/tests/test_profile_view.py
+++ b/apps/users/tests/test_profile_view.py
@@ -1,7 +1,7 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from django.contrib.auth import get_user_model
 
 
 class ProfileViewTests(APITestCase):
@@ -61,10 +61,10 @@ class ProfileViewTests(APITestCase):
     def test_update_profile_invalid_data(self):
         """Test profile update with invalid data"""
         self.client.force_authenticate(user=self.user)
-        invalid_data = {"email": "not-an-email"}
-        response = self.client.put(self.url, invalid_data, format="json")
+        invalid_data = {"password": "short"}
+        response = self.client.patch(self.url, invalid_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("email", response.data)
+        self.assertIn("password", response.data)
 
     def test_profile_unauthorized_access(self):
         """Test unauthorized profile access"""
@@ -79,9 +79,7 @@ class ProfileViewTests(APITestCase):
         for method in methods:
             with self.subTest(method=method):
                 response = getattr(self.client, method)(self.url)
-                self.assertEqual(
-                    response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
-                )
+                self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_password_validation_success(self):
         """Test successful password update with valid password"""

--- a/apps/users/tests/test_user_model.py
+++ b/apps/users/tests/test_user_model.py
@@ -10,9 +10,7 @@ class TestUserModel:
     @pytest.fixture
     def user(self):
         User = get_user_model()
-        return User.objects.create_user(
-            email="test@example.com", password="testpass123"
-        )
+        return User.objects.create_user(email="test@example.com", password="testpass123")
 
     def test_create_user(self, user):
         """Test regular user creation"""

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -35,11 +35,6 @@ class LoginView(KnoxLoginView):
         logger.info("User %s logged in.", user.email)
         return super(LoginView, self).post(request, format=None)
 
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        context["request"] = self.request
-        return context
-
 
 @extend_schema_view(
     get=extend_schema(responses=PROFILE_DETAIL_SCHEMA),

--- a/conf/__init__.py
+++ b/conf/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app

--- a/conf/celery.py
+++ b/conf/celery.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 from celery import Celery

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -61,6 +61,13 @@ X_FRAME_OPTIONS = "DENY"
 CSRF_COOKIE_SECURE = not DEBUG
 SESSION_COOKIE_SECURE = not DEBUG
 
+if not DEBUG:
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_SSL_REDIRECT = True
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # -----------------------------------------------------------------------------
 # Databases
 # -----------------------------------------------------------------------------
@@ -118,7 +125,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
             ],
-            "builtins": ["django.template.defaultfilters"],
+            "builtins": [],
         },
     },
 ]
@@ -187,7 +194,7 @@ if DEBUG:
 
 CORS_ALLOW_ALL_ORIGINS = DEBUG
 if not CORS_ALLOW_ALL_ORIGINS:
-    CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS")
+    CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=[])
 
 # -----------------------------------------------------------------------------
 # Cache
@@ -202,7 +209,6 @@ CACHES = {
     }
 }
 
-USER_AGENTS_CACHE = "default"
 
 # -----------------------------------------------------------------------------
 # Celery
@@ -281,16 +287,13 @@ LOGGING = {
 }
 
 if not DEBUG:
-    sentry_sdk.init(
-        dsn=env("SENTRY_DSN"),
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for tracing.
-        traces_sample_rate=1.0,
-        # Set profiles_sample_rate to 1.0 to profile 100%
-        # of sampled transactions.
-        # We recommend adjusting this value in production.
-        profiles_sample_rate=1.0,
-    )
+    sentry_dsn = env("SENTRY_DSN", default=None)
+    if sentry_dsn:
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            traces_sample_rate=0.1,
+            profiles_sample_rate=0.1,
+        )
 
 # -----------------------------------------------------------------------------
 # Static & Media Files
@@ -310,7 +313,6 @@ STATIC_ROOT = tempfile.mkdtemp() if DEBUG else root_path("static_root")
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = root_path("media_root")
-ADMIN_MEDIA_PREFIX = STATIC_URL + "admin/"
 
 # -----------------------------------------------------------------------------
 # Django Debug Toolbar and Django Extensions

--- a/conf/test_settings.py
+++ b/conf/test_settings.py
@@ -1,18 +1,20 @@
 from .settings import *  # noqa
 
-# Ensure Knox is properly configured for tests
-if "knox" not in INSTALLED_APPS:  # noqa
-    INSTALLED_APPS += ["knox"]  # noqa
-if "django.middleware.common.CommonMiddleware" in MIDDLEWARE:  # noqa
-    index = MIDDLEWARE.index("django.middleware.common.CommonMiddleware") + 1  # noqa
-    MIDDLEWARE.insert(index, "conf.test_utils.RequestIDMiddleware")  # noqa
-else:
-    MIDDLEWARE.append("conf.test_utils.RequestIDMiddleware")  # noqa
+# Use local memory cache so throttles don't persist across test runs
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}
 
-# Test-specific logging configuration
+# Match production middleware ordering — insert at position 0
+MIDDLEWARE.insert(0, "conf.test_utils.RequestIDMiddleware")  # noqa
+
+# Use mock filter that provides all JSON formatter fields
 LOGGING["filters"]["request_id"]["()"] = "conf.test_utils.RequestIDFilter"  # noqa
-LOGGING["handlers"]["console"]["filters"] = []  # noqa
 LOGGING["loggers"]["apps"]["level"] = "DEBUG"  # noqa
 
 # Relax throttling for tests
 REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user_login"] = "1000/minute"  # noqa
+REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"] = "1000/minute"  # noqa
+REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["anon"] = "1000/minute"  # noqa

--- a/conf/test_utils.py
+++ b/conf/test_utils.py
@@ -1,8 +1,13 @@
 class RequestIDFilter:
-    """Mock filter for tests that adds a test request ID"""
+    """Mock filter for tests that provides dummy values for all log record fields"""
 
     def filter(self, record):
         record.request_id = "test-request-id"
+        record.client = "127.0.0.1"
+        record.path = "/test/"
+        record.user_id = "anonymous"
+        record.status_code = 200
+        record.response_time = 0.0
         return True
 
 

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = conf.test_settings
 python_files = tests.py test_*.py *_tests.py
+addopts = --reuse-db --nomigrations

--- a/scripts/celery.py
+++ b/scripts/celery.py
@@ -1,9 +1,0 @@
-from subprocess import check_call
-
-
-def run_worker():
-    check_call(["celery", "-A", "conf", "worker", "--loglevel=info"])
-
-
-def run_beat():
-    check_call(["celery", "-A", "conf", "beat", "--loglevel=info"])


### PR DESCRIPTION
## [0.5.3](https://github.com/wilfredinni/django-starter-template/releases/tag/0.5.3) - 2026-05-30

Bug fixes, security hardening, test infra improvements, and code cleanup

### Fixed

- **Test auth header mismatch** — `test_login_view.py` used `"Token"` prefix but Knox `AUTH_HEADER_PREFIX` is `"Bearer"`. Test was returning 401 instead of 200.
- **Test logging crash** — `test_settings.py` cleared console handler filters, but JSON formatter expected fields injected by `RequestIDFilter`. Mock filter now provides dummy values for all fields.
- **Unhandled CORS env var** — `env.list("CORS_ALLOWED_ORIGINS")` had no default, crashing startup when `DEBUG=False` and env var missing.
- **Sentry startup crash** — `sentry_sdk.init()` required `SENTRY_DSN` in non-DEBUG mode. Now gated on env var existence with graceful fallback.
- **Sentry 100% sampling** — Both `traces_sample_rate` and `profiles_sample_rate` reduced to `0.1` in production to avoid quota exhaustion.
- **Password validation bypass** — `UserProfileSerializer.validate()` passed blank model instance to `validate_password()` instead of `self.instance`, letting `UserAttributeSimilarityValidator` miss email/name comparisons.
- **Email field writable** — `email` field allowed modification via PUT/PATCH without verification. Made read-only in `UserProfileSerializer`.
- **Missing HSTS headers** — Added `SECURE_HSTS_SECONDS`, `SECURE_SSL_REDIRECT`, and `SECURE_PROXY_SSL_HEADER` when `DEBUG=False`.
- **Wrong middleware ordering in tests** — Mock `RequestIDMiddleware` inserted after `CommonMiddleware` instead of position 0, causing behavior mismatch with production.
- **Seed command error swallowing** — `except Exception` caught everything with misleading "already exists" message. Narrowed to `IntegrityError`. Removed `@transaction.atomic` from outer handler; per-user savepoints prevent total rollback on individual failures.
- **Shared Redis throttle state** — Test throttles persisted across runs via shared Redis cache. Switched tests to `LocMemCache` to isolate throttle state.
- **Test throttles incomplete** — Only `user_login` throttle was relaxed in tests; `user` and `anon` rates now also set to `1000/minute`.

### Removed

- `ADMIN_MEDIA_PREFIX` (dead config, removed in Django 2.0)
- `USER_AGENTS_CACHE` (orphan setting, `django-user-agents` not installed)
- `from __future__ import absolute_import, unicode_literals` from `conf/__init__.py` and `conf/celery.py` (Python 2 compat, dead code)
- `django.template.defaultfilters` from template `builtins` (all default filters already available)
- Dead `get_serializer_context()` override in `LoginView` (DRF already injects `request`)
- Redundant `KeyError` from `BaseTaskWithRetry.autoretry_for` (subclass of `Exception`)
- `scripts/celery.py` (dead code, never referenced)
- Stale `.pyc` files in `scripts/__pycache__/` (orphaned from deleted `django.py`)

### Changed

- `CustomUserManager.create_user()` now uses `user.save(using=self._db)` for multi-DB safety
- `RequestIDMiddleware` uses `request.user.pk` instead of `request.user.id` as canonical identifier
- ruff `target-version` and mypy `python_version` updated from `py313` to `py314` (matches runtime)
- `pytest.ini` now includes `addopts = --reuse-db --nomigrations` for faster test setup